### PR TITLE
[WIP] Add publication filtering to resource picker

### DIFF
--- a/src/embedded/ResourcePicker/ResourcePicker.tsx
+++ b/src/embedded/ResourcePicker/ResourcePicker.tsx
@@ -12,6 +12,7 @@ export interface Props {
   products?: boolean,
   collections?: boolean,
   allowMultiple?: boolean,
+  showHidden?: boolean,
   onCancel?(): void,
   onSelection?(selection: SelectionResult): void,
 }

--- a/src/embedded/easdk/components/ResourcePicker.ts
+++ b/src/embedded/easdk/components/ResourcePicker.ts
@@ -6,6 +6,7 @@ export interface OpenOptions {
   products?: boolean,
   collections?: boolean,
   allowMultiple?: boolean,
+  showHidden?: boolean,
   onCancel?(): void,
   onSelection?(resources: object[]): void,
 }
@@ -17,7 +18,7 @@ export default class ResourcePicker {
     this.modal.close();
   }
 
-  open({title, products, collections, allowMultiple = false, onCancel, onSelection}: OpenOptions) {
+  open({title, products, collections, allowMultiple = false, showHidden = true, onCancel, onSelection}: OpenOptions) {
     this.modal.storeCloseCallback((success: boolean, data: any) => {
       if (!success) {
         if (onCancel != null) { onCancel(); }
@@ -36,12 +37,14 @@ export default class ResourcePicker {
       this.messenger.send('Shopify.API.Modal.collectionPicker', {
         title,
         selectMultiple: allowMultiple,
+        showHidden,
         selectable_resources: resources,
       });
     } else {
       this.messenger.send('Shopify.API.Modal.productPicker', {
         title,
         selectMultiple: allowMultiple,
+        showHidden,
         selectable_resources: resources,
       });
     }


### PR DESCRIPTION
By default the resource picker will show all products and collections on a shop, and visually denote which ones are "Hidden" in the case of resources not published to a channel. This adds support for a boolean flag named "showHidden" that defaults to true to preserve the current behaviour.