### PR TITLE
Allow CallbackAction in breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 
 import Icon from '../Icon';
 import UnstyledLink from '../UnstyledLink';
-import {LinkAction} from '../../types';
+import {CallbackAction, LinkAction} from '../../types';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
 
 import * as styles from './Breadcrumbs.scss';
 
 export interface Props {
-  breadcrumbs: LinkAction[],
+  breadcrumbs: Array<CallbackAction|LinkAction>,
 }
 
 export default class Breadcrumbs extends React.PureComponent<Props, never> {


### PR DESCRIPTION
I need `onAction` in order to `pushState` instead of reloading the page.

I've tested it with EASDK and it works, but since I'm using TypeScript it is complaining here that the type declaration does not allow `onAction` :/