### PR TITLE
Fix TS1192 error: Module has no default export

### DIFF
--- a/src/components/ExceptionList/ExceptionList.tsx
+++ b/src/components/ExceptionList/ExceptionList.tsx
@@ -1,4 +1,5 @@
-import React, {Fragment} from 'react';
+import * as React from 'react';
+import {Fragment} from 'react';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
 
 import Icon from '../Icon';

--- a/src/components/Truncate/Truncate.tsx
+++ b/src/components/Truncate/Truncate.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import * as styles from './Truncate.scss';
 
 export interface Props {


### PR DESCRIPTION
The actual error is raised when importing the generated `*.d.ts` files:

`polaris/types/components/ExceptionList/ExceptionList.d.ts`
`polaris/types/components/Truncate/Truncate.d.ts`