### PR TITLE
Fix marginTop typo

### DIFF
--- a/polaris.shopify.com/components/Layout/Layout.css.ts
+++ b/polaris.shopify.com/components/Layout/Layout.css.ts
@@ -3,7 +3,7 @@ import {atoms, vars} from '@polaris/components';
 
 export const root = composeStyles(
   atoms({
-    margin: '4x',
+    margin: '4',
   }),
   style({
     fontFamily: vars.fonts.body,


### PR DESCRIPTION
Changing `4x` to `4` to resolve a typo that threw the following error when running local dev server:

![Screen Shot 2021-07-07 at 8 44 41 AM](https://user-images.githubusercontent.com/4642404/124791961-69ec7e80-df01-11eb-9674-205bea4d32fc.png)
