### PR TITLE
Use Box as the basis for Flex

### DIFF
--- a/@polaris/components/src/atoms/atoms.css.ts
+++ b/@polaris/components/src/atoms/atoms.css.ts
@@ -30,6 +30,7 @@ const styles = createAtomicStyles({
     ],
     // Flex
     flexDirection: ['row', 'column', 'row-reverse', 'column-reverse'],
+    flexWrap: ['wrap', 'nowrap', 'wrap-reverse'],
     alignItems: [...flexAlignment, 'baseline'],
     alignSelf: [...flexAlignment, 'baseline'],
     justifyContent: [
@@ -39,7 +40,6 @@ const styles = createAtomicStyles({
       'space-between',
     ],
     justifySelf: flexAlignment,
-    wrap: ['wrap', 'nowrap', 'wrap-reverse'],
     gap: spacing,
     flexGrow: [0, 1],
     flexShrink: [0],

--- a/@polaris/components/src/components/Box/Box.tsx
+++ b/@polaris/components/src/components/Box/Box.tsx
@@ -8,34 +8,7 @@ export interface BoxProps
       AllHTMLAttributes<HTMLElement>,
       'content' | 'height' | 'translate' | 'color' | 'width' | 'cursor'
     >,
-    Pick<
-      Atoms,
-      | 'display'
-      | 'margin'
-      | 'marginX'
-      | 'marginY'
-      | 'marginTop'
-      | 'marginBottom'
-      | 'marginLeft'
-      | 'marginRight'
-      | 'padding'
-      | 'paddingX'
-      | 'paddingY'
-      | 'paddingTop'
-      | 'paddingBottom'
-      | 'paddingLeft'
-      | 'paddingRight'
-      | 'textAlign'
-      | 'flexDirection'
-      | 'alignItems'
-      | 'alignSelf'
-      | 'justifyContent'
-      | 'justifySelf'
-      | 'wrap'
-      | 'gap'
-      | 'flexGrow'
-      | 'flexShrink'
-    > {
+    Atoms {
   component?: ElementType;
 }
 
@@ -64,7 +37,7 @@ export const Box = forwardRef<HTMLElement, BoxProps>(
       alignSelf,
       justifyContent,
       justifySelf,
-      wrap,
+      flexWrap,
       gap,
       flexGrow,
       flexShrink,
@@ -95,7 +68,7 @@ export const Box = forwardRef<HTMLElement, BoxProps>(
         alignSelf,
         justifyContent,
         justifySelf,
-        wrap,
+        flexWrap,
         gap,
         flexGrow,
         flexShrink,
@@ -110,3 +83,5 @@ export const Box = forwardRef<HTMLElement, BoxProps>(
     });
   },
 );
+
+Box.displayName = 'Box';

--- a/@polaris/components/src/components/Flex/Flex.css.ts
+++ b/@polaris/components/src/components/Flex/Flex.css.ts
@@ -1,5 +1,0 @@
-import {style} from '@vanilla-extract/css';
-
-export const flex = style({
-  display: 'flex',
-});

--- a/@polaris/components/src/components/Flex/Flex.tsx
+++ b/@polaris/components/src/components/Flex/Flex.tsx
@@ -1,67 +1,47 @@
-import {createElement, forwardRef, AllHTMLAttributes, ElementType} from 'react';
-import classnames from 'classnames';
+import React, {forwardRef} from 'react';
 
-import {atoms, Atoms} from '../../atoms/atoms.css';
+import {Atoms} from '../../atoms';
+import {Box, BoxProps} from '../Box/Box';
 
-import * as styles from './Flex.css';
-
-export interface FlexProps
-  extends Omit<
-      AllHTMLAttributes<HTMLElement>,
-      'content' | 'height' | 'translate' | 'color' | 'width' | 'cursor'
-    >,
-    Pick<
-      Atoms,
-      | 'flexDirection'
-      | 'alignItems'
-      | 'alignSelf'
-      | 'justifyContent'
-      | 'justifySelf'
-      | 'wrap'
-      | 'gap'
-      | 'flexGrow'
-      | 'flexShrink'
-    > {
-  component?: ElementType;
+export interface FlexProps extends Omit<BoxProps, 'wrap'> {
+  align?: Atoms['flexDirection'];
+  basis?: Atoms['flexBasis'];
+  direction?: Atoms['flexDirection'];
+  grow?: Atoms['flexGrow'];
+  justify?: Atoms['justifyContent'];
+  shrink?: Atoms['flexShrink'];
+  wrap?: Atoms['flexWrap'];
 }
 
 export const Flex = forwardRef<HTMLElement, FlexProps>(
   (
     {
-      component = 'div',
-      flexDirection,
-      alignItems,
-      alignSelf,
-      justifyContent,
-      justifySelf,
+      align,
+      basis,
+      direction,
+      grow,
+      justify,
+      shrink,
       wrap,
-      gap,
-      flexGrow,
-      flexShrink,
       ...restProps
     }: FlexProps,
     ref,
   ) => {
-    const className = classnames(
-      styles.flex,
-      atoms({
-        flexDirection,
-        alignItems,
-        alignSelf,
-        justifyContent,
-        justifySelf,
-        wrap,
-        gap,
-        flexGrow,
-        flexShrink,
-      }),
-      restProps.className,
+    return (
+      <Box
+        ref={ref}
+        display="flex"
+        alignItems={align}
+        flexBasis={basis}
+        flexDirection={direction}
+        flexGrow={grow}
+        flexShrink={shrink}
+        flexWrap={wrap}
+        justifyContent={justify}
+        {...restProps}
+      />
     );
-
-    return createElement(component, {
-      ...restProps,
-      className,
-      ref,
-    });
   },
 );
+
+Flex.displayName = 'Flex';

--- a/polaris.shopify.com/pages/index.tsx
+++ b/polaris.shopify.com/pages/index.tsx
@@ -11,7 +11,7 @@ const IndexPage = () => {
   return (
     <Layout>
       <Heading>
-        <Box margin="4" display="flex" alignItems="center" gap="4">
+        <Flex align="center" gap="4" margin="4">
           <span role="img" aria-label={sparkles}>
             ✨
           </span>
@@ -20,7 +20,7 @@ const IndexPage = () => {
           </Text>
 
           <Text>working in the open</Text>
-        </Box>
+        </Flex>
       </Heading>
 
       <Box margin="4">


### PR DESCRIPTION
In follow-up of the [Box discussion](https://github.com/Shopify/polaris/discussions/49), I wanted to explore using the Box as the base component to build other components.

Essentially, this makes Flex a `Box` with `display: flex` and comes with helpful style shorthand (align, basis, direction, justify, grow, shrink, wrap)

Some advantages I see here:

* Static reuse of the atomic styles created by `atoms.css.ts` and used by Box
* No `style={}` object interpolation on render
* Remove the need for `Flex.css.ts`
* Reuse `component` logic (all components can be polymorphic)
* Reuse `classnames` functionality (all components get `classnames` merging superpowers)
* The syntax is a little easier to ready (imo)
* And we can consistently opt for JSX rather than the `createElement` method

Examples:

```jsx
<Flex align="center" />

<Flex align="center" padding="4" wrap="wrap" />

<Flex component="section" justify="space-around" />

<Flex
  component="section"
  justify="space-around"
  className={{ '.is-active': isActive, '.conditional-class': isValid }}
/>
```

Related to #87