### PR TITLE
[Grid, Flex] Add missing alignment props

### DIFF
--- a/src/@polaris/components/src/components/Box/Box.tsx
+++ b/src/@polaris/components/src/components/Box/Box.tsx
@@ -9,12 +9,6 @@ export interface BoxProps
       'content' | 'height' | 'translate' | 'color' | 'width' | 'cursor'
     >,
     Atoms {
-  grid?: string;
-  gridArea?: string;
-  gridAutoRows?: string;
-  gridTemplateAreas?: string[];
-  gridTemplateColumns?: string[];
-  gridTemplateRows?: string[];
   component?: ElementType;
 }
 
@@ -49,13 +43,7 @@ export const Box = forwardRef<HTMLElement, BoxProps>(
       gap,
       flexGrow,
       flexShrink,
-      grid,
-      gridArea,
-      gridAutoRows,
-      gridTemplateAreas,
-      gridTemplateColumns,
-      gridTemplateRows,
-      ...restProps
+      ...rest
     },
     ref,
   ) => {
@@ -89,23 +77,12 @@ export const Box = forwardRef<HTMLElement, BoxProps>(
         flexGrow,
         flexShrink,
       }),
-      restProps.className,
+      rest.className,
     );
 
     return createElement(component, {
-      ...restProps,
+      ...rest,
       className,
-      style: {
-        grid,
-        gridArea,
-        gridTemplateAreas: gridTemplateAreas
-          ? `'${gridTemplateAreas.join(`' '`)}'`
-          : null,
-        gridAutoRows,
-        gridTemplateColumns: gridTemplateColumns?.join(' '),
-        gridTemplateRows: gridTemplateRows?.join(' '),
-        ...restProps.style,
-      },
       ref,
     });
   },

--- a/src/@polaris/components/src/components/Flex/Flex.tsx
+++ b/src/@polaris/components/src/components/Flex/Flex.tsx
@@ -4,32 +4,47 @@ import {Atoms} from '../../atoms';
 import {Box, BoxProps} from '../Box/Box';
 
 export interface FlexProps extends Omit<BoxProps, 'wrap' | 'placeContent'> {
-  align?: Atoms['alignItems'];
+  alignItems?: Atoms['alignItems'];
+  alignSelf?: Atoms['alignSelf'];
+  justifyContent?: Atoms['justifyContent'];
+  justifySelf?: Atoms['justifySelf'];
   basis?: Atoms['flexBasis'];
   direction?: Atoms['flexDirection'];
   grow?: Atoms['flexGrow'];
-  justify?: Atoms['justifyContent'];
   shrink?: Atoms['flexShrink'];
   wrap?: Atoms['flexWrap'];
 }
 
 export const Flex = forwardRef<HTMLElement, FlexProps>(
   (
-    {align, basis, direction, grow, justify, shrink, wrap, ...restProps},
+    {
+      alignItems,
+      alignSelf,
+      basis,
+      direction,
+      grow,
+      justifyContent,
+      justifySelf,
+      shrink,
+      wrap,
+      ...rest
+    },
     ref,
   ) => {
     return (
       <Box
         ref={ref}
         display="flex"
-        alignItems={align}
+        alignItems={alignItems}
+        alignSelf={alignSelf}
+        justifyContent={justifyContent}
+        justifySelf={justifySelf}
         flexBasis={basis}
         flexDirection={direction}
         flexGrow={grow}
         flexShrink={shrink}
         flexWrap={wrap}
-        justifyContent={justify}
-        {...restProps}
+        {...rest}
       />
     );
   },

--- a/src/@polaris/components/src/components/Flex/Flex.tsx
+++ b/src/@polaris/components/src/components/Flex/Flex.tsx
@@ -4,10 +4,6 @@ import {Atoms} from '../../atoms';
 import {Box, BoxProps} from '../Box/Box';
 
 export interface FlexProps extends Omit<BoxProps, 'wrap' | 'placeContent'> {
-  alignItems?: Atoms['alignItems'];
-  alignSelf?: Atoms['alignSelf'];
-  justifyContent?: Atoms['justifyContent'];
-  justifySelf?: Atoms['justifySelf'];
   basis?: Atoms['flexBasis'];
   direction?: Atoms['flexDirection'];
   grow?: Atoms['flexGrow'];
@@ -16,29 +12,11 @@ export interface FlexProps extends Omit<BoxProps, 'wrap' | 'placeContent'> {
 }
 
 export const Flex = forwardRef<HTMLElement, FlexProps>(
-  (
-    {
-      alignItems,
-      alignSelf,
-      basis,
-      direction,
-      grow,
-      justifyContent,
-      justifySelf,
-      shrink,
-      wrap,
-      ...rest
-    },
-    ref,
-  ) => {
+  ({basis, direction, grow, shrink, wrap, ...rest}, ref) => {
     return (
       <Box
         ref={ref}
         display="flex"
-        alignItems={alignItems}
-        alignSelf={alignSelf}
-        justifyContent={justifyContent}
-        justifySelf={justifySelf}
         flexBasis={basis}
         flexDirection={direction}
         flexGrow={grow}

--- a/src/@polaris/components/src/components/Grid/Grid.tsx
+++ b/src/@polaris/components/src/components/Grid/Grid.tsx
@@ -1,30 +1,24 @@
-import React, {forwardRef, ElementType} from 'react';
+import React, {forwardRef} from 'react';
 
 import {Atoms} from '../../atoms/atoms.css';
 import {Box, BoxProps} from '../Box/Box';
 
 export interface GridProps extends Omit<BoxProps, 'rows'> {
-  alignItems?: Atoms['alignItems'];
-  alignSelf?: Atoms['alignSelf'];
-  justifyContent?: Atoms['justifyContent'];
-  justifySelf?: Atoms['justifySelf'];
   gap?: Atoms['gap'];
   place?: Atoms['placeContent'];
   grid?: string;
   rows?: string[];
   autoRows?: string;
+  autoColumns?: string;
   columns?: string[];
   areas?: string[];
   area?: string;
-  component?: ElementType;
 }
 
 export const Grid = forwardRef<HTMLElement, GridProps>(
   (
     {
       component,
-      alignItems,
-      alignSelf,
       gap,
       grid,
       area,
@@ -32,8 +26,7 @@ export const Grid = forwardRef<HTMLElement, GridProps>(
       columns,
       rows,
       autoRows,
-      justifyContent,
-      justifySelf,
+      autoColumns,
       place,
       ...rest
     },
@@ -45,10 +38,6 @@ export const Grid = forwardRef<HTMLElement, GridProps>(
         ref={ref}
         display="grid"
         component={component}
-        alignItems={alignItems}
-        alignSelf={alignSelf}
-        justifyContent={justifyContent}
-        justifySelf={justifySelf}
         gap={gap}
         placeContent={place}
         style={{
@@ -57,9 +46,10 @@ export const Grid = forwardRef<HTMLElement, GridProps>(
           gridTemplateColumns: columns?.join(' '),
           gridTemplateRows: rows?.join(' '),
           gridAutoRows: autoRows,
-          ...(areas?.length
-            ? {gridTemplateAreas: `'${areas.join(`' '`)}'`}
-            : {}),
+          gridAutoColumns: autoColumns,
+          gridTemplateAreas: areas?.length
+            ? `'${areas.join(`' '`)}'`
+            : undefined,
           ...style,
         }}
         {...props}

--- a/src/@polaris/components/src/components/Grid/Grid.tsx
+++ b/src/@polaris/components/src/components/Grid/Grid.tsx
@@ -4,8 +4,10 @@ import {Atoms} from '../../atoms/atoms.css';
 import {Box, BoxProps} from '../Box/Box';
 
 export interface GridProps extends Omit<BoxProps, 'rows'> {
-  align?: Atoms['alignItems'];
-  justify?: Atoms['justifyContent'];
+  alignItems?: Atoms['alignItems'];
+  alignSelf?: Atoms['alignSelf'];
+  justifyContent?: Atoms['justifyContent'];
+  justifySelf?: Atoms['justifySelf'];
   gap?: Atoms['gap'];
   place?: Atoms['placeContent'];
   grid?: string;
@@ -20,7 +22,9 @@ export interface GridProps extends Omit<BoxProps, 'rows'> {
 export const Grid = forwardRef<HTMLElement, GridProps>(
   (
     {
-      align,
+      component,
+      alignItems,
+      alignSelf,
       gap,
       grid,
       area,
@@ -28,27 +32,37 @@ export const Grid = forwardRef<HTMLElement, GridProps>(
       columns,
       rows,
       autoRows,
-      justify,
+      justifyContent,
+      justifySelf,
       place,
-      ...restProps
+      ...rest
     },
     ref,
   ) => {
+    const {style, ...props} = rest;
     return (
       <Box
         ref={ref}
         display="grid"
-        grid={grid}
-        gridArea={area}
-        gridTemplateAreas={areas}
-        gridTemplateColumns={columns}
-        gridTemplateRows={rows}
-        gridAutoRows={autoRows}
-        alignItems={align}
-        justifyContent={justify}
+        component={component}
+        alignItems={alignItems}
+        alignSelf={alignSelf}
+        justifyContent={justifyContent}
+        justifySelf={justifySelf}
         gap={gap}
         placeContent={place}
-        {...restProps}
+        style={{
+          grid,
+          gridArea: area,
+          gridTemplateColumns: columns?.join(' '),
+          gridTemplateRows: rows?.join(' '),
+          gridAutoRows: autoRows,
+          ...(areas?.length
+            ? {gridTemplateAreas: `'${areas.join(`' '`)}'`}
+            : {}),
+          ...style,
+        }}
+        {...props}
       />
     );
   },

--- a/src/polaris.shopify.com/pages/index.tsx
+++ b/src/polaris.shopify.com/pages/index.tsx
@@ -17,7 +17,7 @@ const IndexPage = () => {
   return (
     <Layout>
       <Heading>
-        <Flex align="center" gap="4" margin="4">
+        <Flex alignItems="center" gap="4" margin="4">
           <span role="img" aria-label={sparkles}>
             ✨
           </span>
@@ -40,12 +40,12 @@ const IndexPage = () => {
 
       <Box margin="4">
         <Grid gap="4" areas={GRID_TEMPLATE_AREAS}>
-          <GridItem gridArea="area1">area 1</GridItem>
-          <GridItem gridArea="area2">area 2</GridItem>
-          <GridItem gridArea="area3">area 3</GridItem>
-          <GridItem gridArea="area4">area 4</GridItem>
-          <GridItem gridArea="area5">area 5</GridItem>
-          <GridItem gridArea="area6">area 6</GridItem>
+          <GridItem area="area1">area 1</GridItem>
+          <GridItem area="area2">area 2</GridItem>
+          <GridItem area="area3">area 3</GridItem>
+          <GridItem area="area4">area 4</GridItem>
+          <GridItem area="area5">area 5</GridItem>
+          <GridItem area="area6">area 6</GridItem>
         </Grid>
       </Box>
 


### PR DESCRIPTION
Closing https://github.com/Shopify/polaris/pull/148 in favour of this.

We can figure out if we need subcomponents like Grid.Item in the future