### PR TITLE
Do not render 'class' if no class props are passed

### DIFF
--- a/src/@polaris/components/src/components/Box/Box.tsx
+++ b/src/@polaris/components/src/components/Box/Box.tsx
@@ -78,7 +78,7 @@ export const Box = forwardRef<HTMLElement, BoxProps>(
         flexShrink,
       }),
       rest.className,
-    );
+    ) || null;
 
     return createElement(component, {
       ...rest,


### PR DESCRIPTION
The `Box` property adds an empty `class` html attribute even when there are no class props passed to the component (see screenshot below). This PR will default the `className` prop to `null` to prevent it from adding the `class` attribute if empty.

![](https://screenshot.click/Polaris_2021-07-14_12-22-27.png)

## Testing instructions:
1. in the `page/index.tsx` sandbox add another `Box` component with whatever content you want.
2. Save, open the page in your browser and inspect your new element. There should be no `class` attribute in the element.
3. add a `className` prop value to your new `Box` component.
4. Save, open the page in your browser and inspect your new element. You should see a `class` attribute in the element that matches the value you passed.
5. add one of the `Box` props that matches those defined in the `Box` component (e.x. `margin='1'`).
6. Save, open the page in your browser and inspect your new element. You should see a `class` attribute in the element that includes the class(es) that map to the prop you passed along.

![](https://screenshot.click/14-32-aysdi-zqry8.png)

