### PR TITLE
Map style to UNSAFE_style on Box

### DIFF
--- a/src/@polaris/components/src/components/Box/Box.tsx
+++ b/src/@polaris/components/src/components/Box/Box.tsx
@@ -1,4 +1,10 @@
-import {createElement, forwardRef, AllHTMLAttributes, ElementType} from 'react';
+import React, {
+  createElement,
+  forwardRef,
+  AllHTMLAttributes,
+  ElementType,
+  CSSProperties,
+} from 'react';
 import classnames from 'classnames';
 
 import {atoms, Atoms} from '../../atoms';
@@ -6,9 +12,17 @@ import {atoms, Atoms} from '../../atoms';
 export interface BoxProps
   extends Omit<
       AllHTMLAttributes<HTMLElement>,
-      'content' | 'height' | 'translate' | 'color' | 'width' | 'cursor' | 'size'
+      | 'content'
+      | 'height'
+      | 'translate'
+      | 'color'
+      | 'width'
+      | 'cursor'
+      | 'size'
+      | 'style'
     >,
     Atoms {
+  UNSAFE_style?: CSSProperties;
   component?: ElementType;
 }
 
@@ -53,6 +67,7 @@ export const Box = forwardRef<HTMLElement, BoxProps>(
       minHeight,
       maxHeight,
       color,
+      UNSAFE_style,
       ...rest
     },
     ref,
@@ -104,6 +119,7 @@ export const Box = forwardRef<HTMLElement, BoxProps>(
     return createElement(component, {
       ...rest,
       className,
+      style: UNSAFE_style,
       ref,
     });
   },

--- a/src/@polaris/components/src/components/Grid/Grid.tsx
+++ b/src/@polaris/components/src/components/Grid/Grid.tsx
@@ -32,7 +32,7 @@ export const Grid = forwardRef<HTMLElement, GridProps>(
     },
     ref,
   ) => {
-    const {style, ...props} = rest;
+    const {UNSAFE_style, ...props} = rest;
     return (
       <Box
         ref={ref}
@@ -40,7 +40,7 @@ export const Grid = forwardRef<HTMLElement, GridProps>(
         component={component}
         gap={gap}
         placeContent={place}
-        style={{
+        UNSAFE_style={{
           grid,
           gridArea: area,
           gridTemplateColumns: columns?.join(' '),
@@ -50,7 +50,7 @@ export const Grid = forwardRef<HTMLElement, GridProps>(
           gridTemplateAreas: areas?.length
             ? `'${areas.join(`' '`)}'`
             : undefined,
-          ...style,
+          ...UNSAFE_style,
         }}
         {...props}
       />

--- a/src/polaris.shopify.com/pages/index.tsx
+++ b/src/polaris.shopify.com/pages/index.tsx
@@ -84,9 +84,9 @@ const IndexPage = () => {
 
       <Box margin="4">
         <Stack align="center" justify="space-evenly" spacing="4">
-          <BoxItem style={{minHeight: '100px'}}>Stack 1</BoxItem>
-          <BoxItem style={{minHeight: '80px'}}>Stack 2</BoxItem>
-          <BoxItem style={{minHeight: '120px'}}>Stack 3</BoxItem>
+          <BoxItem UNSAFE_style={{minHeight: '100px'}}>Stack 1</BoxItem>
+          <BoxItem UNSAFE_style={{minHeight: '80px'}}>Stack 2</BoxItem>
+          <BoxItem UNSAFE_style={{minHeight: '120px'}}>Stack 3</BoxItem>
         </Stack>
       </Box>
 
@@ -94,21 +94,26 @@ const IndexPage = () => {
 
       <Box margin="4">
         <Inline align="center" justify="flex-end" spacing="4">
-          <BoxItem style={{minWidth: '100px'}}>Inline 1</BoxItem>
-          <BoxItem style={{minWidth: '80px'}}>Inline 2</BoxItem>
-          <BoxItem style={{minWidth: '120px'}}>Inline 3</BoxItem>
+          <BoxItem UNSAFE_style={{minWidth: '100px'}}>Inline 1</BoxItem>
+          <BoxItem UNSAFE_style={{minWidth: '80px'}}>Inline 2</BoxItem>
+          <BoxItem UNSAFE_style={{minWidth: '120px'}}>Inline 3</BoxItem>
         </Inline>
       </Box>
 
       {/* negative margins */}
       <Box margin="4">
         <Inline align="center" spacing="-5">
-          <BoxItem style={{minWidth: '80px', border: 'solid black 1px'}}>Inline 1</BoxItem>
-          <BoxItem style={{minWidth: '80px', border: 'solid black 1px'}}>Inline 2</BoxItem>
-          <BoxItem style={{minWidth: '80px', border: 'solid black 1px'}}>Inline 3</BoxItem>
+          <BoxItem UNSAFE_style={{minWidth: '80px', border: 'solid black 1px'}}>
+            Inline 1
+          </BoxItem>
+          <BoxItem UNSAFE_style={{minWidth: '80px', border: 'solid black 1px'}}>
+            Inline 2
+          </BoxItem>
+          <BoxItem UNSAFE_style={{minWidth: '80px', border: 'solid black 1px'}}>
+            Inline 3
+          </BoxItem>
         </Inline>
       </Box>
-
     </Layout>
   );
 };


### PR DESCRIPTION
Using the style prop is less performant than using atoms or creating stylesheets. Let's discourage it by mapping it to `UNSAFE_style` on the Box component