### PR TITLE
Add build step to shipit config

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -2,5 +2,7 @@ dependencies:
   override:
     - yarn
 deploy:
+  pre:
+    - yarn build
   override:
     - buildkite-trigger polaris-publish-package


### PR DESCRIPTION
Our [first try at publishing](https://shipit.shopify.io/shopify/polaris/experimental/deploys/1326264) failed, and I think it is due to not running `yarn build`.

Trying again but with a build pre publish.
