### PR TITLE
Add slack channel to service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,2 +1,4 @@
 # https://services.shopify.io/services/polaris
+slack_channels:
+  - polaris
 classification: library


### PR DESCRIPTION
Resolves [Shopify/services#2451](https://github.com/Shopify/services/issues/2451), which flags that the service.yml was missing a valid public Slack channel.