### PR TITLE
Remove self-imports to @polaris/components within @polaris/components

### DIFF
--- a/src/@polaris/components/src/components/Box/Box.tsx
+++ b/src/@polaris/components/src/components/Box/Box.tsx
@@ -1,6 +1,6 @@
 import {createElement, forwardRef, AllHTMLAttributes, ElementType} from 'react';
-import {classNames} from '@polaris/components';
 
+import {classNames} from '../utilities/css';
 import {atoms, Atoms} from '../../atoms';
 
 export interface BoxProps

--- a/src/@polaris/components/src/components/Link/Link.tsx
+++ b/src/@polaris/components/src/components/Link/Link.tsx
@@ -1,5 +1,6 @@
 import React, {ElementType, createElement, AllHTMLAttributes} from 'react';
-import {classNames} from '@polaris/components';
+
+import {classNames} from '../utilities/css';
 
 import {variant, linkStyle} from './Link.css';
 

--- a/src/@polaris/components/src/components/Text/Text.tsx
+++ b/src/@polaris/components/src/components/Text/Text.tsx
@@ -5,8 +5,8 @@ import {
   ElementType,
   ReactNode,
 } from 'react';
-import {classNames} from '@polaris/components';
 
+import {classNames} from '../utilities/css';
 import {atoms, Atoms} from '../../atoms/atoms.css';
 
 import * as styles from './Text.css';


### PR DESCRIPTION
Though our path aliases can understand and process path imports to the same package, Vite cannot build using self-referencing imports.

This commit replaces internal package references to `@polaris/components` with relative path imports.