### PR TITLE
Add dev script to run build in watch mode and dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   ],
   "scripts": {
     "build": "lerna run --scope @polaris/* build",
+    "watch": "lerna run --parallel watch",
+    "dev": "concurrently npm:watch npm:site",
     "site": "lerna run --stream --scope website dev",
     "lint": "eslint '**/*.{js,ts,tsx}'",
     "tsc": "tsc --noEmit",
@@ -25,6 +27,7 @@
     "@vanilla-extract/css": "^1.2.1",
     "@vanilla-extract/sprinkles": "^1.0.0",
     "@vanilla-extract/vite-plugin": "^1.1.1",
+    "concurrently": "^6.2.1",
     "eslint": "^7.27.0",
     "jest": "^27.0.1",
     "lerna": "^4.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "build": "yarn build:js && yarn build:types",
     "build:js": "vite build",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationDir dist/types"
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationDir dist/types",
+    "watch": "vite build --watch"
   },
   "dependencies": {
     "@polaris/tokens": "*"

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -12,7 +12,8 @@ export default defineConfig({
       formats: ['es', 'cjs'],
       fileName: (format) => `polaris-components.${format}.js`,
     },
-    outDir: './dist',
+    outDir: resolve(__dirname, './dist'),
+    emptyOutDir: false,
     rollupOptions: {
       external: Object.keys(pkg.peerDependencies),
     },

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "build": "yarn build:js && yarn build:types",
     "build:js": "vite build",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationDir dist/types"
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationDir dist/types",
+    "watch": "vite build --watch"
   }
 }

--- a/packages/tokens/vite.config.ts
+++ b/packages/tokens/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       formats: ['es', 'cjs'],
       fileName: (format) => `polaris-tokens.${format}.js`,
     },
-    outDir: './dist',
+    outDir: resolve(__dirname, './dist'),
+    emptyOutDir: false,
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3254,6 +3254,21 @@ concat-stream@^2.0.0:
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
+concurrently@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-6.2.1.tgz#d880fc1d77559084732fa514092a3d5109a0d5bf"
+  integrity sha512-emgwhH+ezkuYKSHZQ+AkgEpoUZZlbpPVYCVv7YZx0r+T7fny1H03r2nYRebpi2DudHR4n1Rgbo2YTxKOxVJ4+g==
+  dependencies:
+    chalk "^4.1.0"
+    date-fns "^2.16.1"
+    lodash "^4.17.21"
+    read-pkg "^5.2.0"
+    rxjs "^6.6.3"
+    spawn-command "^0.0.2-1"
+    supports-color "^8.1.0"
+    tree-kill "^1.2.2"
+    yargs "^16.2.0"
+
 config-chain@^1.1.12:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4"
@@ -3516,6 +3531,11 @@ dataloader@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
   integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
+
+date-fns@^2.16.1:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.23.0.tgz#4e886c941659af0cf7b30fafdd1eaa37e88788a9"
+  integrity sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==
 
 dateformat@^3.0.0:
   version "3.0.3"
@@ -7657,7 +7677,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^6.6.0:
+rxjs@^6.6.0, rxjs@^6.6.3:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -7876,6 +7896,11 @@ source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+spawn-command@^0.0.2-1:
+  version "0.0.2-1"
+  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
+  integrity sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=
 
 spawndamnit@^2.0.0:
   version "2.0.0"
@@ -8146,7 +8171,7 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.0.0:
+supports-color@^8.0.0, supports-color@^8.1.0:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -8358,6 +8383,11 @@ tr46@^2.0.2, tr46@^2.1.0:
   integrity sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==
   dependencies:
     punycode "^2.1.1"
+
+tree-kill@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
 trim-newlines@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
## Added scripts

- `watch` - rebuilds packages when files change
- `site` - runs the website using the dev server
- `dev` – runs `watch` and `site` concurrently

Closes #201

## Tophatting

Run `dev up` then `dev s`

## Improvements

The builds aren't being cached and the process could be more efficient using more specialized tooling like [nx.dev](https://nx.dev). However, before adding more tooling, I thought this could be a good starting point until we see a stronger need.