### PR TITLE
Hacking some strict overrides

### DIFF
--- a/website/components/AdminBox/AdminBox.tsx
+++ b/website/components/AdminBox/AdminBox.tsx
@@ -1,0 +1,21 @@
+import React, {AllHTMLAttributes} from 'react';
+import {Box as PolarisBox} from '@polaris/components';
+
+import {atoms, Atoms} from './strict-atoms.css';
+
+interface Props
+  extends Atoms,
+    Omit<
+      AllHTMLAttributes<HTMLElement>,
+      'content' | 'height' | 'translate' | 'color' | 'width' | 'cursor' | 'size'
+    > {}
+export function AdminBox(props: Props) {
+  const {style, children, ...rest} = props;
+  const className = atoms({...rest});
+
+  return (
+    <PolarisBox className={className} style={style}>
+      {children}
+    </PolarisBox>
+  );
+}

--- a/website/components/AdminBox/index.ts
+++ b/website/components/AdminBox/index.ts
@@ -1,0 +1,1 @@
+export * from './AdminBox';

--- a/website/components/AdminBox/strict-atoms.css.ts
+++ b/website/components/AdminBox/strict-atoms.css.ts
@@ -1,0 +1,40 @@
+import {createAtomicStyles, createAtomsFn} from '@vanilla-extract/sprinkles';
+
+const baseUnit = 16;
+const baseFontSize = 10;
+
+function rem(value: number) {
+  return `${value / baseFontSize}rem`;
+}
+
+const sizes = {
+  zero: rem(0),
+  one: rem(1),
+  baseExtraTight: rem(baseUnit / 4),
+  baseTight: rem(baseUnit / 2),
+  base: rem(baseUnit),
+  baseLoose: rem(baseUnit * 2),
+  baseExtraLoose: rem(baseUnit * 4),
+};
+
+const responsiveStyles = createAtomicStyles({
+  properties: {
+    height: {...sizes, full: '100%'},
+    width: {...sizes, full: '100%'},
+    maxHeight: {...sizes, full: '100%'},
+    maxWidth: {...sizes, full: '100%'},
+    marginBottom: sizes,
+    marginLeft: sizes,
+    marginRight: sizes,
+    marginTop: sizes,
+  },
+  shorthands: {
+    margin: ['marginTop', 'marginBottom', 'marginLeft', 'marginRight'],
+    marginX: ['marginLeft', 'marginRight'],
+    marginY: ['marginTop', 'marginBottom'],
+  },
+});
+
+export const atoms = createAtomsFn(responsiveStyles);
+
+export type Atoms = Parameters<typeof atoms>[0];

--- a/website/pages/index.tsx
+++ b/website/pages/index.tsx
@@ -1,50 +1,39 @@
 import React from 'react';
-import {Box, Flex, Inline, Stack} from '@polaris/components';
+import {Stack} from '@polaris/components';
 
+import {AdminBox} from '../components/AdminBox';
 import {Layout} from '../components/Layout';
 
 const IndexPage = () => {
   return (
     <Layout>
-      <h2>Flex</h2>
-      <Flex gap={4}>
-        <Box style={{backgroundColor: 'silver'}} height={16} width="1/3" />
-        <Box style={{backgroundColor: 'silver'}} height={20} width="1/3" />
-        <Box style={{backgroundColor: 'silver'}} height={24} width="1/3" />
-      </Flex>
+      <Stack gap={4}>
+        <AdminBox
+          width="full"
+          height="baseLoose"
+          style={{backgroundColor: 'silver'}}
+        >
+          Admin box 1
+        </AdminBox>
 
-      <Divider />
+        <AdminBox
+          width="full"
+          height="base"
+          style={{backgroundColor: 'silver'}}
+        >
+          Admin box 2
+        </AdminBox>
 
-      <h2>Stack</h2>
-      <Stack gap={2} align="center">
-        <Box style={{backgroundColor: 'silver'}} height={16} width="1/3" />
-        <Box style={{backgroundColor: 'silver'}} height={20} width="1/3" />
-        <Box style={{backgroundColor: 'silver'}} height={24} width="1/3" />
+        <AdminBox
+          width="full"
+          height="baseExtraTight"
+          style={{backgroundColor: 'silver'}}
+        >
+          Admin box 3
+        </AdminBox>
       </Stack>
-
-      <Divider />
-
-      <h2>Inline – Wrap (Default)</h2>
-      <Inline gap={2}>
-        <Box style={{backgroundColor: 'silver'}} height={16} width="1/3" />
-        <Box style={{backgroundColor: 'silver'}} height={20} width="1/3" />
-        <Box style={{backgroundColor: 'silver'}} height={24} width="1/3" />
-      </Inline>
-
-      <Divider />
-
-      <h2>Inline – No wrap</h2>
-      <Inline gap={2} wrap="nowrap">
-        <Box style={{backgroundColor: 'silver'}} height={16} width="1/3" />
-        <Box style={{backgroundColor: 'silver'}} height={20} width="1/3" />
-        <Box style={{backgroundColor: 'silver'}} height={24} width="1/3" />
-      </Inline>
     </Layout>
   );
 };
-
-const Divider = () => (
-  <Box margin={4} height="px" style={{backgroundColor: 'silver'}} />
-);
 
 export default IndexPage;


### PR DESCRIPTION
Just exploring one way of taking an open component (box) and making it stricter. The idea here is that some design systems might want to limit the properties on their elements. They can do that with out built components by wrapping them in a layer

Here's what the markup would look like with the build / unbuilt atoms:

![image](https://screenshot.click/Polaris_2021-08-18_13-56-41.png)

There are lots of drawbacks to this approach but it was neat to explore