### PR TITLE
[Tokens] Add breakpoints

### DIFF
--- a/packages/components/src/atoms/atoms.css.ts
+++ b/packages/components/src/atoms/atoms.css.ts
@@ -1,16 +1,10 @@
 import {createAtomicStyles, createAtomsFn} from '@vanilla-extract/sprinkles';
+// using values from tokens due to CSS scoping issue when using `vars`
+import {breakpoints} from '@polaris/tokens';
 
 import {vars} from '../theme/vars.css';
 
 const flexAlignment = ['flex-start', 'center', 'flex-end', 'stretch'] as const;
-
-const breakpoints = {
-  xs: '0px',
-  sm: '600px',
-  md: '960px',
-  lg: '1280px',
-  xl: '1920px',
-};
 
 const spacing = {
   ...vars.spacing,

--- a/packages/components/src/theme/vars.css.ts
+++ b/packages/components/src/theme/vars.css.ts
@@ -2,6 +2,7 @@ import {createTheme, createThemeContract} from '@vanilla-extract/css';
 import * as tokens from '@polaris/tokens';
 
 const theme = {
+  breakpoints: tokens.breakpoints,
   spacing: tokens.spacing,
 };
 

--- a/packages/tokens/src/breakpoints.ts
+++ b/packages/tokens/src/breakpoints.ts
@@ -1,4 +1,5 @@
 export const breakpoints = {
+  xs: '0',
   sm: '600px',
   md: '960px',
   lg: '1280px',

--- a/packages/tokens/src/breakpoints.ts
+++ b/packages/tokens/src/breakpoints.ts
@@ -1,0 +1,6 @@
+export const breakpoints = {
+    sm: '600px',
+    md: '960px',
+    lg: '1280px',
+    xl: '1920px',
+};

--- a/packages/tokens/src/breakpoints.ts
+++ b/packages/tokens/src/breakpoints.ts
@@ -1,6 +1,6 @@
 export const breakpoints = {
-    sm: '600px',
-    md: '960px',
-    lg: '1280px',
-    xl: '1920px',
+  sm: '600px',
+  md: '960px',
+  lg: '1280px',
+  xl: '1920px',
 };

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -1,1 +1,2 @@
+export {breakpoints} from './breakpoints';
 export {spacing} from './spacing';


### PR DESCRIPTION
Closes #180 

Moves breakpoints from `atoms` to `tokens` (and exposes them to both the `theme` and `atoms`).

Co-Authored-By: Sam Rose <samrose3@gmail.com>