### PR TITLE
Remove defaultVars export from theme root

### DIFF
--- a/packages/components/src/theme/index.ts
+++ b/packages/components/src/theme/index.ts
@@ -1,6 +1,4 @@
 export {defaultTheme, createTheme} from './createTheme';
 
-export {defaultVars} from './vars.css';
-
 export {ThemeProvider, useTheme} from './ThemeProvider';
 export type {ThemeProviderProps} from './ThemeProvider';


### PR DESCRIPTION
Co-Authored-By: Aaron Casanova <32409546+aaronccasanova@users.noreply.github.com>

This fixes an error on build because we can't import `defaultVars` from `./theme`. This is a constraint from `vanilla-extract` as `devaultVars` must be imported from a `.css.ts` file, which is evaluated at build time.