### PR TITLE
feat: Add FocusLock component

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -33,7 +33,8 @@
     "@polaris/tokens": "*",
     "@radix-ui/react-polymorphic": "^0.0.13",
     "clsx": "^1.1.1",
-    "deepmerge": "^4.2.2"
+    "deepmerge": "^4.2.2",
+    "react-focus-on": "^3.5.2"
   },
   "peerDependencies": {
     "@vanilla-extract/css": "^1.2.1",

--- a/packages/components/src/components/FocusLock/FocusLock.tsx
+++ b/packages/components/src/components/FocusLock/FocusLock.tsx
@@ -38,48 +38,48 @@ interface Props {
    * [focus-lock] Allows "ignoring" focus on some elements
    * @see {@link https://github.com/theKashey/react-focus-lock#api}
    */
-  shouldIgnore?: (candidate: HTMLElement) => boolean;
+  shouldIgnore?: FocusOnProps['shouldIgnore'];
 
   /**
    * Action to perform on Esc key press
    */
-  onEscapeKey?: (event: Event) => void;
+  onEscapeKey?: FocusOnProps['onEscapeKey'];
 
   /**
    * Action to perform on click outside
    */
-  onClickOutside?: (event: MouseEvent | TouchEvent) => void;
+  onClickOutside?: FocusOnProps['onClickOutside'];
 
   /**
    * Callback on lock activation
    * @param node The main node
    */
-  onActivation?: (node: HTMLElement) => void;
+  onActivation?: FocusOnProps['onActivation'];
 
   /**
    * Callback on lock deactivation
    */
-  onDeactivation?: () => void;
+  onDeactivation?: FocusOnProps['onDeactivation'];
 
   /**
    * [scroll-lock] Control isolation
    * @see {@link https://github.com/theKashey/react-remove-scroll#usage}
    */
-  noIsolation?: boolean;
+  noIsolation?: FocusOnProps['noIsolation'];
 
   /**
    * [scroll-lock] Full page inert (event suppression)
    * @default false
    * @see {@link https://github.com/theKashey/react-remove-scroll#usage}
    */
-  inert?: boolean;
+  inert?: FocusOnProps['inert'];
 
   /**
    * [scroll-lock] Allows scroll based zoom
    * @default false
    * @see https://github.com/theKashey/react-remove-scroll#usage
    */
-  allowPinchZoom?: boolean;
+  allowPinchZoom?: FocusOnProps['allowPinchZoom'];
 }
 
 // Default React.ElementType derived from the following declaration file:

--- a/packages/components/src/components/FocusLock/FocusLock.tsx
+++ b/packages/components/src/components/FocusLock/FocusLock.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import {FocusOn} from 'react-focus-on';
+import type * as Polymorphic from '@radix-ui/react-polymorphic';
+
+type FocusOnProps = React.ComponentProps<typeof FocusOn>;
+
+interface Props {
+  children: React.ReactNode;
+
+  /**
+   * The main switch
+   */
+  enabled?: FocusOnProps['enabled'];
+
+  /**
+   * Controls scroll lock behavior
+   */
+  scrollLock?: FocusOnProps['scrollLock'];
+
+  /**
+   * Controls focus lock behavior
+   */
+  focusLock?: FocusOnProps['focusLock'];
+
+  /**
+   * [focus-lock] Control autofocus
+   * @default true
+   */
+  autoFocus?: FocusOnProps['autoFocus'];
+
+  /**
+   * [focus-lock] Control returnFocus
+   * @default true
+   */
+  returnFocus?: FocusOnProps['returnFocus'];
+
+  /**
+   * [focus-lock] Allows "ignoring" focus on some elements
+   * @see {@link https://github.com/theKashey/react-focus-lock#api}
+   */
+  shouldIgnore?: (candidate: HTMLElement) => boolean;
+
+  /**
+   * Action to perform on Esc key press
+   */
+  onEscapeKey?: (event: Event) => void;
+
+  /**
+   * Action to perform on click outside
+   */
+  onClickOutside?: (event: MouseEvent | TouchEvent) => void;
+
+  /**
+   * Callback on lock activation
+   * @param node The main node
+   */
+  onActivation?: (node: HTMLElement) => void;
+
+  /**
+   * Callback on lock deactivation
+   */
+  onDeactivation?: () => void;
+
+  /**
+   * [scroll-lock] Control isolation
+   * @see {@link https://github.com/theKashey/react-remove-scroll#usage}
+   */
+  noIsolation?: boolean;
+
+  /**
+   * [scroll-lock] Full page inert (event suppression)
+   * @default false
+   * @see {@link https://github.com/theKashey/react-remove-scroll#usage}
+   */
+  inert?: boolean;
+
+  /**
+   * [scroll-lock] Allows scroll based zoom
+   * @default false
+   * @see https://github.com/theKashey/react-remove-scroll#usage
+   */
+  allowPinchZoom?: boolean;
+}
+
+// Default React.ElementType derived from the following declaration file:
+// https://github.com/theKashey/react-focus-on/blob/50c6059db9365934603e1d3074daf8298442c8c2/src/types.ts#L88-L92
+type PolymorphicFocusLock = Polymorphic.ForwardRefComponent<'div', Props>;
+
+export type FocusLockProps = Polymorphic.OwnProps<PolymorphicFocusLock>;
+
+export const FocusLock = React.forwardRef((props, ref) => {
+  return <FocusOn ref={ref} {...props} />;
+}) as PolymorphicFocusLock;

--- a/packages/components/src/components/FocusLock/index.ts
+++ b/packages/components/src/components/FocusLock/index.ts
@@ -1,0 +1,2 @@
+export {FocusLock} from './FocusLock';
+export type {FocusLockProps} from './FocusLock';

--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -3,6 +3,7 @@ export * from './Box';
 export * from './Center';
 export * from './Container';
 export * from './Flex';
+export * from './FocusLock';
 export * from './Grid';
 export * from './Inline';
 export * from './Portal';

--- a/website/pages/index.tsx
+++ b/website/pages/index.tsx
@@ -1,11 +1,64 @@
 import React from 'react';
-import {Box, Flex, Inline, Stack} from '@polaris/components';
+import {Box, Flex, Inline, Stack, FocusLock} from '@polaris/components';
 
 import {Layout} from '../components/Layout';
 
 const IndexPage = () => {
+  const [isFocusLocked, setIsFocusLocked] = React.useState(false);
+  const [isScrollLocked, setScrollLocked] = React.useState(false);
+
+  function toggleFocusLock() {
+    setIsFocusLocked((prevIsFocusLocked) => !prevIsFocusLocked);
+  }
+
+  function toggleScrollLock() {
+    setScrollLocked((prevIsScrollLocked) => !prevIsScrollLocked);
+  }
+
   return (
     <Layout>
+      <h2>Focus Lock</h2>
+      <p>isFocusLocked: {isFocusLocked.toString()}</p>
+      <p>isScrollLocked: {isScrollLocked.toString()}</p>
+
+      <br />
+      <br />
+
+      <button type="button" onClick={toggleFocusLock}>
+        Toggle Focus Lock
+      </button>
+      <button type="button" onClick={toggleScrollLock}>
+        Toggle Scroll Lock
+      </button>
+      {/* eslint-disable-next-line jsx-a11y/accessible-emoji */}
+      <p>
+        👆 Focus will return to this button when the Focus Lock is disabled.
+      </p>
+
+      <br />
+      <br />
+
+      <FocusLock
+        focusLock={isFocusLocked}
+        scrollLock={isScrollLocked}
+        onEscapeKey={toggleFocusLock}
+      >
+        <h3>Focus Lock Group</h3>
+        <Flex gap={4}>
+          <button type="button" onClick={toggleFocusLock}>
+            Toggle Focus Lock
+          </button>
+          <button type="button" onClick={toggleFocusLock}>
+            Toggle Focus Lock
+          </button>
+          <button type="button" onClick={toggleFocusLock}>
+            Toggle Focus Lock
+          </button>
+        </Flex>
+      </FocusLock>
+
+      <Divider />
+
       <h2>Flex</h2>
       <Flex gap={4}>
         <Box style={{backgroundColor: 'silver'}} height={16} width="1/3" />
@@ -17,6 +70,27 @@ const IndexPage = () => {
 
       <h2>Stack</h2>
       <Stack gap={2} align="center">
+        <Box style={{backgroundColor: 'silver'}} height={16} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={20} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={24} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={16} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={20} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={24} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={16} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={20} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={24} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={16} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={20} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={24} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={16} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={20} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={24} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={16} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={20} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={24} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={16} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={20} width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height={24} width="1/3" />
         <Box style={{backgroundColor: 'silver'}} height={16} width="1/3" />
         <Box style={{backgroundColor: 'silver'}} height={20} width="1/3" />
         <Box style={{backgroundColor: 'silver'}} height={24} width="1/3" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5343,6 +5343,13 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
+invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
+
 is-absolute-url@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-3.0.3.tgz#96c6a22b6a23929b11ea0afb1836c36ad4a5d698"

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,6 +466,13 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.13":
+  version "7.15.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.3.tgz#2e1c2880ca118e5b2f9988322bd8a7656a32502b"
+  integrity sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.9.2":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.8.tgz#7119a56f421018852694290b9f9148097391b446"
@@ -3048,6 +3055,13 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-hidden@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.1.3.tgz#bb48de18dc84787a3c6eee113709c473c64ec254"
+  integrity sha512-RhVWFtKH5BiGMycI72q2RAFMLQi8JP9bLuQXgR5a8Znp7P5KOIADSJeyfI8PCVxLEp067B2HbP5JIiI/PXIZeA==
+  dependencies:
+    tslib "^1.0.0"
+
 aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
@@ -4842,6 +4856,11 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
+
 devtools-protocol@0.0.901419:
   version "0.0.901419"
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.901419.tgz#79b5459c48fe7e1c5563c02bd72f8fec3e0cebcd"
@@ -5891,6 +5910,13 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+focus-lock@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.9.1.tgz#e8ec7d4821631112193ae09258107f531588da01"
+  integrity sha512-/2Nj60Cps6yOLSO+CkVbeSKfwfns5XbX6HOedIK9PdzODP04N9c3xqOcPXayN0WsT9YjJvAnXmI0NdqNIDf5Kw==
+  dependencies:
+    tslib "^2.0.3"
+
 follow-redirects@^1.10.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
@@ -6070,6 +6096,11 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
+
+get-nonce@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
 
 get-package-type@^0.1.0:
   version "0.1.0"
@@ -6686,6 +6717,13 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
 
 ip@^1.1.5:
   version "1.1.5"
@@ -8031,7 +8069,7 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
-loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -10051,6 +10089,13 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
+react-clientside-effect@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.5.tgz#e2c4dc3c9ee109f642fac4f5b6e9bf5bcd2219a3"
+  integrity sha512-2bL8qFW1TGBHozGGbVeyvnggRpMjibeZM2536AKNENLECutp2yfs44IL8Hmpn8qjFQ2K7A9PnYf3vc7aQq/cPA==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+
 react-dom@^17.0.0:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
@@ -10059,6 +10104,30 @@ react-dom@^17.0.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-focus-lock@^2.5.0:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.5.2.tgz#f1e4db5e25cd8789351f2bd5ebe91e9dcb9c2922"
+  integrity sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    focus-lock "^0.9.1"
+    prop-types "^15.6.2"
+    react-clientside-effect "^1.2.5"
+    use-callback-ref "^1.2.5"
+    use-sidecar "^1.0.5"
+
+react-focus-on@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/react-focus-on/-/react-focus-on-3.5.2.tgz#65cd20e05d8b38248ddc95998780037aff6b4b2b"
+  integrity sha512-tpPxLqw9tEuElWmcr5jqw/ULfJjdHEnom0nBW9p6y75Zsa0wOfwQNqCHqCoJcHUqSBtKXqTuYduZoSTfTOTdJw==
+  dependencies:
+    aria-hidden "^1.1.2"
+    react-focus-lock "^2.5.0"
+    react-remove-scroll "^2.4.1"
+    react-style-singleton "^2.1.1"
+    use-callback-ref "^1.2.5"
+    use-sidecar "^1.0.5"
 
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
@@ -10074,6 +10143,25 @@ react-refresh@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.10.0.tgz#2f536c9660c0b9b1d500684d9e52a65e7404f7e3"
   integrity sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==
+
+react-remove-scroll-bar@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.2.0.tgz#d4d545a7df024f75d67e151499a6ab5ac97c8cdd"
+  integrity sha512-UU9ZBP1wdMR8qoUs7owiVcpaPwsQxUDC2lypP6mmixaGlARZa7ZIBx1jcuObLdhMOvCsnZcvetOho0wzPa9PYg==
+  dependencies:
+    react-style-singleton "^2.1.0"
+    tslib "^1.0.0"
+
+react-remove-scroll@^2.4.1:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.4.3.tgz#83d19b02503b04bd8141ed6e0b9e6691a2e935a6"
+  integrity sha512-lGWYXfV6jykJwbFpsuPdexKKzp96f3RbvGapDSIdcyGvHb7/eqyn46C7/6h+rUzYar1j5mdU+XECITHXCKBk9Q==
+  dependencies:
+    react-remove-scroll-bar "^2.1.0"
+    react-style-singleton "^2.1.0"
+    tslib "^1.0.0"
+    use-callback-ref "^1.2.3"
+    use-sidecar "^1.0.1"
 
 react-router-dom@^5.2.0:
   version "5.2.0"
@@ -10103,6 +10191,15 @@ react-router@5.2.0:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-style-singleton@^2.1.0, react-style-singleton@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.1.1.tgz#ce7f90b67618be2b6b94902a30aaea152ce52e66"
+  integrity sha512-jNRp07Jza6CBqdRKNgGhT3u9umWvils1xsuMOjZlghBDH2MU0PL2WZor4PGYjXpnRCa9DQSlHMs/xnABWOwYbA==
+  dependencies:
+    get-nonce "^1.0.0"
+    invariant "^2.2.4"
+    tslib "^1.0.0"
 
 react@^17.0.0, react@^17.0.2:
   version "17.0.2"
@@ -11620,7 +11717,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.0.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -11887,6 +11984,19 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-callback-ref@^1.2.3, use-callback-ref@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.5.tgz#6115ed242cfbaed5915499c0a9842ca2912f38a5"
+  integrity sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==
+
+use-sidecar@^1.0.1, use-sidecar@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.5.tgz#ffff2a17c1df42e348624b699ba6e5c220527f2b"
+  integrity sha512-k9jnrjYNwN6xYLj1iaGhonDghfvmeTmYjAiGvOr7clwKfPjMXJf4/HOr7oT5tJwYafgp2tG2l3eZEOfoELiMcA==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^1.9.3"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
### Short Description:
As a prerequisite to [building the Modal component](https://github.com/Shopify/polaris/issues/260), this PR exposes a `FocusLock` component that handles focus trapping, scroll locking, and hiding aria/screen reader content from the page (which can be individually applied through the extensive prop interface).

- Added `react-focus-on` as a dependency to `@polaris/components`
- Created a `FocusLock` component (which is a wrapper around the `FocusOn` component exported from `react-focus-on`) 
  Note: Our wrapper exposes a limited selection of props from `react-focus-on` to ensure we are providing enough flexibility to handle common use cases while still allowing us to change the underlying libraries in the future.
  
### Examples

#### Demonstrates activating the focus lock and returning the previously focus element on deactivation.

https://user-images.githubusercontent.com/32409546/131747626-cabb163e-c575-4c39-8112-5a213f66e695.mov

#### Demonstrates the scroll lock functionality

https://user-images.githubusercontent.com/32409546/131747832-786f73b9-8c65-4ea7-836b-5f47522e8fff.mov
