### PR TITLE
fix: Build website using component src code

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "lerna run --scope @polaris/* build",
     "watch": "lerna run --parallel watch",
-    "dev": "concurrently npm:watch npm:site",
+    "dev": "yarn site",
     "site": "lerna run --stream --scope website dev",
     "lint": "eslint '**/*.{js,ts,tsx}'",
     "tsc": "tsc --noEmit",
@@ -20,14 +20,14 @@
     "cypress": "start-server-and-test 'yarn run dev' http-get://localhost:3000 'yarn run cy:run'",
     "version": "changeset version && yarn",
     "release": "yarn build && changeset publish",
-    "postinstall": "lerna bootstrap && yarn build",
+    "postinstall": "lerna bootstrap & yarn build",
     "size": "yarn build && size-limit",
     "clean": "lerna exec -- rm -rf ./dist && lerna exec -- rm -rf ./node_modules"
   },
   "dependencies": {
     "@vanilla-extract/css": "^1.2.1",
     "@vanilla-extract/sprinkles": "^1.0.0",
-    "@vanilla-extract/vite-plugin": "^1.1.1",
+    "@vanilla-extract/vite-plugin": "^2.0.1",
     "react": "^17.0.0",
     "vite": "^2.4.4"
   },

--- a/website/components/Heading/Heading.tsx
+++ b/website/components/Heading/Heading.tsx
@@ -1,5 +1,6 @@
 import React, {ComponentProps} from 'react';
-import {Box} from '@polaris/components';
+
+import {Box} from '../../../packages/components/src';
 
 export const Heading = (props: ComponentProps<typeof Box>) => (
   <Box {...props} />

--- a/website/components/Layout/Layout.css.ts
+++ b/website/components/Layout/Layout.css.ts
@@ -1,5 +1,5 @@
-import {atoms} from '@polaris/components';
+import {atoms} from '../../../packages/components/src';
 
 export const root = atoms({
-  marginY: 4,
+  marginY: '4',
 });

--- a/website/components/Layout/Layout.tsx
+++ b/website/components/Layout/Layout.tsx
@@ -1,7 +1,7 @@
 import React, {ComponentProps} from 'react';
 import clsx from 'clsx';
-import {Container, ThemeProvider} from '@polaris/components';
 
+import {Container, ThemeProvider} from '../../../packages/components/src';
 import {themeClass} from '../theme.css';
 
 import {root} from './Layout.css';

--- a/website/components/theme.css.ts
+++ b/website/components/theme.css.ts
@@ -1,3 +1,3 @@
-import {createTheme} from '@polaris/components';
+import {createTheme} from '../../packages/components/src';
 
 export const [themeClass, vars] = createTheme();

--- a/website/main.tsx
+++ b/website/main.tsx
@@ -2,7 +2,6 @@ import React, {Suspense, lazy} from 'react';
 import ReactDOM from 'react-dom';
 import {BrowserRouter as Router, Route, Switch} from 'react-router-dom';
 
-import '@polaris/components/styles';
 import './styles/index.css';
 
 const Index = lazy(() => import('./pages'));

--- a/website/package.json
+++ b/website/package.json
@@ -10,8 +10,6 @@
     "start": "vite preview"
   },
   "dependencies": {
-    "@polaris/components": "*",
-    "@polaris/tokens": "*",
     "@vanilla-extract/css": "^1.2.1",
     "@vanilla-extract/sprinkles": "^1.0.0",
     "clsx": "^1.1.1",

--- a/website/pages/index.tsx
+++ b/website/pages/index.tsx
@@ -1,50 +1,50 @@
 import React from 'react';
-import {Box, Flex, Inline, Stack} from '@polaris/components';
 
+import {Box, Flex, Inline, Stack} from '../../packages/components/src';
 import {Layout} from '../components/Layout';
 
 const IndexPage = () => {
   return (
     <Layout>
       <h2>Flex</h2>
-      <Flex gap={4}>
-        <Box style={{backgroundColor: 'silver'}} height={16} width="1/3" />
-        <Box style={{backgroundColor: 'silver'}} height={20} width="1/3" />
-        <Box style={{backgroundColor: 'silver'}} height={24} width="1/3" />
+      <Flex gap="4">
+        <Box style={{backgroundColor: 'silver'}} height="16" width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height="20" width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height="24" width="1/3" />
       </Flex>
 
       <Divider />
 
       <h2>Stack</h2>
-      <Stack gap={2} align="center">
-        <Box style={{backgroundColor: 'silver'}} height={16} width="1/3" />
-        <Box style={{backgroundColor: 'silver'}} height={20} width="1/3" />
-        <Box style={{backgroundColor: 'silver'}} height={24} width="1/3" />
+      <Stack gap="2" align="center">
+        <Box style={{backgroundColor: 'silver'}} height="16" width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height="20" width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height="24" width="1/3" />
       </Stack>
 
       <Divider />
 
       <h2>Inline – Wrap (Default)</h2>
-      <Inline gap={2}>
-        <Box style={{backgroundColor: 'silver'}} height={16} width="1/3" />
-        <Box style={{backgroundColor: 'silver'}} height={20} width="1/3" />
-        <Box style={{backgroundColor: 'silver'}} height={24} width="1/3" />
+      <Inline gap="2">
+        <Box style={{backgroundColor: 'silver'}} height="16" width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height="20" width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height="24" width="1/3" />
       </Inline>
 
       <Divider />
 
       <h2>Inline – No wrap</h2>
-      <Inline gap={2} wrap="nowrap">
-        <Box style={{backgroundColor: 'silver'}} height={16} width="1/3" />
-        <Box style={{backgroundColor: 'silver'}} height={20} width="1/3" />
-        <Box style={{backgroundColor: 'silver'}} height={24} width="1/3" />
+      <Inline gap="2" wrap="nowrap">
+        <Box style={{backgroundColor: 'silver'}} height="16" width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height="20" width="1/3" />
+        <Box style={{backgroundColor: 'silver'}} height="24" width="1/3" />
       </Inline>
     </Layout>
   );
 };
 
 const Divider = () => (
-  <Box margin={4} height="px" style={{backgroundColor: 'silver'}} />
+  <Box margin="4" height="px" style={{backgroundColor: 'silver'}} />
 );
 
 export default IndexPage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2601,7 +2601,7 @@
     "@typescript-eslint/types" "4.25.0"
     eslint-visitor-keys "^2.0.0"
 
-"@vanilla-extract/css@^1.2.0", "@vanilla-extract/css@^1.2.1":
+"@vanilla-extract/css@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@vanilla-extract/css/-/css-1.2.1.tgz#7928f964a13094b2c23622b935d96310cd8dc388"
   integrity sha512-YANTzzYQCplZRwoZvUa+2iSE2McS/ug8EqOdejeLssRlsQAv213XU1xB8OjZbtRAwXVbl3mWbvbvBZEfNtctBw==
@@ -2615,12 +2615,27 @@
     dedent "^0.7.0"
     deep-object-diff "^1.1.0"
 
-"@vanilla-extract/integration@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@vanilla-extract/integration/-/integration-1.1.0.tgz#7a766608327ffad25896b8d509b9acae07ccbcbc"
-  integrity sha512-VzDodGcoPv8loAyqIPya+UuFOr2c6D4rJ4uhIe4hms94FXZ+0qxPOXvFs7PNamt83M1zkInIj+0kEAHFC1D1gg==
+"@vanilla-extract/css@^1.3.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@vanilla-extract/css/-/css-1.4.0.tgz#6b364d8fbab4dd2dc0bf66aa9af3ea3f2cef2811"
+  integrity sha512-gJ73SxZSkDoc19gKozVD4u8uUq4e0txqDfF0+LYC3e5rlavCdFsssg9XvlglUw75b9FFJAHaBkLAbDDBf3eL3A==
   dependencies:
-    "@vanilla-extract/css" "^1.2.0"
+    "@emotion/hash" "^0.8.0"
+    "@vanilla-extract/private" "^1.0.1"
+    chalk "^4.1.1"
+    css-what "^5.0.1"
+    cssesc "^3.0.0"
+    csstype "^3.0.7"
+    dedent "^0.7.0"
+    deep-object-diff "^1.1.0"
+    deepmerge "^4.2.2"
+
+"@vanilla-extract/integration@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@vanilla-extract/integration/-/integration-1.2.0.tgz#057a9a74bd6bf8ea2cfadb89d9b90fb8629efae9"
+  integrity sha512-mawQst1Kk8LnsTXNcQ5VBTmg11DeYgctUG/G/l4ELlaINUAdvc7mguuf46nqXA1lfkrMbjquaBeiZQ9/Vz6x0g==
+  dependencies:
+    "@vanilla-extract/css" "^1.3.0"
     chalk "^4.1.1"
     dedent "^0.7.0"
     esbuild "^0.11.16"
@@ -2639,12 +2654,12 @@
   resolved "https://registry.yarnpkg.com/@vanilla-extract/sprinkles/-/sprinkles-1.0.0.tgz#44ff25e9782ba48e8a32aa1282d1772df16a2d6d"
   integrity sha512-owMxzIZ9YIMAUNkHfr4B+GKAOW2jaZLCYk66rwRwY2olHS1MX8I0L5CESzRgkh4shuH7sUCUYLhIS247/SLK4w==
 
-"@vanilla-extract/vite-plugin@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@vanilla-extract/vite-plugin/-/vite-plugin-1.1.1.tgz#0fac49e2aad86a50eac3d48b669cf29eb9867f55"
-  integrity sha512-e8UaZowE8YOibE+jsDOhAOVHGClTX0lENbY81yyPRDdmOTz5Zq0umVA+m2LYDg0q1GeiNNmB6drqcS95NubQTw==
+"@vanilla-extract/vite-plugin@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@vanilla-extract/vite-plugin/-/vite-plugin-2.0.1.tgz#61a358a1d70866d2e94386b98ced4f0e05e9cedf"
+  integrity sha512-B6Kftqy0BH62mwbEq5YYAVU362qq0DfmoQmvoITJEydwmDjgldDMZtip/yl1LV7KQrzA7LnUngmat7G0rgAxKQ==
   dependencies:
-    "@vanilla-extract/integration" "^1.1.0"
+    "@vanilla-extract/integration" "^1.2.0"
 
 "@vitejs/plugin-react-refresh@^1.3.1":
   version "1.3.6"


### PR DESCRIPTION
This commit fixes the `[load-fallback] ... *.css` errors. It only changes the import paths to `@polaris/components` in the website to instead use the source code, `[relative path]/packages/components/src`).

## Alternatives

We could change the `main:` property of the components `package.json` to point to the `src/index.ts`, then we could continue importing from `@polaris/components`. This would mean we are shipping uncompiled source code and users would have to have `vanilla-extract` integrated into their build.

## Path aliases

We tried using TS/Vite alias, however, the Vite alias were not working for `.css.ts` files. The plugin should check for Vite alias when resolving imports. This would be a good issue to report to `vanilla-extract/vite-plugin`. Ultimately, if we decide to deliver uncompiled code, then this will be less relevant (since Vite will automatically get the local version of symlinked dependencies in a monorepo).

## Typescript

Notice we had to change our margin and gap values from `number` to `string`. This is due to how the TS compiler will coerce key from a string to a "number" if is is a valid numeric index (ex: `{ "4": "1rem" } => { 4: "1rem" }`)

This isn't ideal and could mean users get different typings depending if they are using the "built" or "source" version of the components library. It isn't super simple to move the scales to use all numeric values since some of the spacing values need to be strings (`{"px": "1px"}`).

Even though it would be more difficult to adopt the system, I am leaning towards **delivering uncompiled assets**. This would:

- Promote and enable users to take full advantage of vanilla-extract and our system
- Prevent changes in typing due to TS compiler coercion
- Simplify our monorepo package and linking (could use `@polars/components` instead of relative paths)
- Remove our `vite.config.ts` for our components package