### PR TITLE
feat(reset): Add element style reset

### DIFF
--- a/packages/components/src/atoms/atoms.ts
+++ b/packages/components/src/atoms/atoms.ts
@@ -1,0 +1,21 @@
+import clsx from 'clsx';
+
+import * as resetStyles from './reset.css';
+import {sprinkles, Sprinkles} from './sprinkles.css';
+
+export interface Atoms extends Sprinkles {
+  reset?: keyof JSX.IntrinsicElements;
+}
+
+export const atoms = ({reset, ...rest}: Atoms) => {
+  if (!reset) {
+    return sprinkles(rest);
+  }
+
+  const elementReset =
+    resetStyles.element[reset as keyof typeof resetStyles.element];
+
+  const sprinklesClasses = sprinkles(rest);
+
+  return clsx(resetStyles.base, elementReset, sprinklesClasses);
+};

--- a/packages/components/src/atoms/index.ts
+++ b/packages/components/src/atoms/index.ts
@@ -1,2 +1,7 @@
-export * from './atoms.css';
-export * from './utils';
+export {atoms} from './atoms';
+export type {Atoms} from './atoms';
+
+export {sprinkles} from './sprinkles.css';
+export type {Sprinkles} from './sprinkles.css';
+
+export {splitProps} from './utils';

--- a/packages/components/src/atoms/reset.css.ts
+++ b/packages/components/src/atoms/reset.css.ts
@@ -1,0 +1,126 @@
+import {style, composeStyles} from '@vanilla-extract/css';
+
+/**
+ * Selector for `focus-visible` package
+ * https://github.com/WICG/focus-visible
+ */
+const hideFocusRingsDataAttribute =
+  '[data-js-focus-visible] &:focus:not([data-focus-visible-added])';
+
+export const base = style({
+  margin: 0,
+  padding: 0,
+  border: 0,
+  boxSizing: 'border-box',
+  fontSize: '100%',
+  font: 'inherit',
+  verticalAlign: 'baseline',
+  WebkitTapHighlightColor: 'transparent',
+  selectors: {
+    [`${hideFocusRingsDataAttribute}`]: {
+      outline: 'none',
+    },
+  },
+});
+
+// HTML5 display-role reset for older browsers
+const block = style({
+  display: 'block',
+});
+
+const body = style({
+  lineHeight: 1,
+});
+
+const list = style({
+  listStyle: 'none',
+});
+
+const quote = style({
+  quotes: 'none',
+  selectors: {
+    '&:before, &:after': {
+      content: "''",
+    },
+  },
+});
+
+const table = style({
+  borderCollapse: 'collapse',
+  borderSpacing: 0,
+});
+
+const appearance = style({
+  appearance: 'none',
+});
+
+const field = composeStyles(block, appearance);
+
+// Custom reset rules
+const mark = style({
+  backgroundColor: 'transparent',
+  color: 'inherit',
+});
+
+const select = composeStyles(
+  field,
+  style({
+    selectors: {
+      '&::-ms-expand': {
+        display: 'none',
+      },
+    },
+  }),
+);
+
+const input = composeStyles(
+  field,
+  style({
+    selectors: {
+      '&::-ms-clear': {
+        display: 'none',
+      },
+      '&::-webkit-search-cancel-button': {
+        WebkitAppearance: 'none',
+      },
+    },
+  }),
+);
+
+const button = style({
+  background: 'none',
+});
+
+// eslint-disable-next-line id-length
+const a = style({
+  textDecoration: 'none',
+  color: 'inherit',
+});
+
+export const element = {
+  article: block,
+  aside: block,
+  details: block,
+  figcaption: block,
+  figure: block,
+  footer: block,
+  header: block,
+  hgroup: block,
+  menu: block,
+  nav: block,
+  section: block,
+  ul: list,
+  ol: list,
+  blockquote: quote,
+  // eslint-disable-next-line id-length
+  q: quote,
+  body,
+  // eslint-disable-next-line id-length
+  a,
+  table,
+  mark,
+  select,
+  button,
+  textarea: field,
+  input,
+};

--- a/packages/components/src/atoms/sprinkles.css.ts
+++ b/packages/components/src/atoms/sprinkles.css.ts
@@ -31,7 +31,7 @@ const sizes = {
   full: '100%',
 };
 
-const unresponsiveStyles = createAtomicStyles({
+export const unresponsiveStyles = createAtomicStyles({
   properties: {
     borderStyle: [
       'none',
@@ -86,7 +86,7 @@ const unresponsiveStyles = createAtomicStyles({
   },
 });
 
-const responsiveStyles = createAtomicStyles({
+export const responsiveStyles = createAtomicStyles({
   conditions: {
     xs: {},
     sm: {'@media': `screen and (min-width: ${breakpoints.sm})`},
@@ -175,6 +175,6 @@ const responsiveStyles = createAtomicStyles({
   },
 });
 
-export const atoms = createAtomsFn(unresponsiveStyles, responsiveStyles);
+export const sprinkles = createAtomsFn(unresponsiveStyles, responsiveStyles);
 
-export type Atoms = Parameters<typeof atoms>[0];
+export type Sprinkles = Parameters<typeof sprinkles>[0];

--- a/packages/components/src/atoms/utils.ts
+++ b/packages/components/src/atoms/utils.ts
@@ -1,7 +1,7 @@
-import {atoms, Atoms} from './atoms.css';
+import {sprinkles, Sprinkles} from './sprinkles.css';
 
-function isAtomsProp(key: string): key is keyof Atoms {
-  return atoms.properties.has(key as keyof Omit<Atoms, 'reset'>);
+function isAtomsProp(key: string): key is keyof Sprinkles {
+  return sprinkles.properties.has(key as keyof Sprinkles);
 }
 
 export function splitProps<T extends {[key: string]: any}>(props: T) {

--- a/packages/components/src/components/Box/Box.tsx
+++ b/packages/components/src/components/Box/Box.tsx
@@ -3,7 +3,7 @@ import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
 import {atoms, Atoms, splitProps} from '../../atoms';
 
-interface Props extends Atoms {}
+interface Props extends Omit<Atoms, 'reset'> {}
 
 type PolymorphicBox = Polymorphic.ForwardRefComponent<'div', Props>;
 
@@ -14,7 +14,10 @@ export const Box = React.forwardRef((props, ref) => {
 
   const {atomProps, nativeProps} = splitProps(restProps);
 
-  const atomicClasses = atoms(atomProps);
+  const atomicClasses = atoms({
+    reset: typeof Component === 'string' ? Component : 'div',
+    ...atomProps,
+  });
 
   return (
     <Component

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,3 +1,6 @@
+// Ensure reset and atoms are the lowest specificity
+import './atoms';
+
 // Atoms
 export * from './atoms';
 


### PR DESCRIPTION
This commit adds "atomic" element-based reset styles that are applied when using the `as` prop on the Box component.

This allows components in our system to inherit shared element reset styles without having to expose the reset styles globally.