### PR TITLE
Documentation MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,85 @@
-# Polaris
+# Shopify Design Foundations
 
-[About this repo](#about-this-repo) | [Projects](#projects) | [How to use this repo](#how-to-use-this-repo) | [Contribute to our explorations](#contribute-to-our-explorations) | [Technical details](#technical-details)
+[About this repo](#about-this-repo) | [Projects](#projects) | [How to use this repo](#how-to-use-this-repo) | [Technical details](#technical-details) | [Contribute to our explorations](#contribute-to-our-explorations) | [Resources](#resources)
+
+---
 
 ## About this repo
 
-> The experience platform for Shopify. This repository is focused on centralizing systems, documentation and foundations.
+The experience platform for Shopify. This repository is focused on centralizing foundational design system resources.
 
 | Current status | Owner                                                                       | Help                                                               |
 | -------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| ongoing        | [@polaris-team](https://github.com/orgs/Shopify/teams/polaris-team/members) | [#polaris](https://shopify.slack.com/app_redirect?channel=polaris) |
+| paused         | [@polaris-team](https://github.com/orgs/Shopify/teams/polaris-team/members) | [#polaris](https://shopify.slack.com/app_redirect?channel=polaris) |
 
-## Projects
+### Projects
 
 A public version of our [Github Project](https://github.com/orgs/Shopify/projects/2250/views/5?type=beta) will be coming soon!
 
-## How to use this repo
+### Development
 
-### polaris.shopify.com quick start guide
-
-Make sure [Git](https://git-scm.com/downloads) and [Node.js](https://nodejs.org/en/) are installed on your computer then run the following commands to get started:
+Make sure [Git](https://git-scm.com/downloads) and [Node.js](https://nodejs.org/en/) are installed on your computer, then run the following commands in your terminal to get started:
 
 ```shell
 $ git clone https://github.com/Shopify/polaris.git    # git clone repository
 $ cd polaris                                          # access the files
 $ npm install                                         # install dependencies
-$ npm run dev                                         # run polars.shopify.com locally
+$ npm run dev                                         # run locally
 ```
 
-## Try out the experimental release
+### Technical details
 
-We have created an [initial release](https://www.npmjs.com/package/@shopify/layout-experimental) for sharing and testing layout components: Box, Grid, Flex, and more. You can check out examples of how they are used and try them out yourself at the [Layout Experimental CodeSandbox](https://codesandbox.io/s/layout-experimental-demo-wcxdj?file=/src/pages/index.js).
-
-See [this discussion](https://github.com/Shopify/polaris/discussions/178) for how to use the experimental components in your own project.
-
-## Contribute to our explorations
-
-We'd love to hear what you think. Start a conversation in [Github Discussions](https://github.com/Shopify/polaris/discussions)!
-
-## Technical details
-
-As we continue to iterate and evolve, these technologies are subject to change. Currently, polaris.shopify.com is built using the following technologies:
+As we continue to iterate and evolve, these technologies are subject to change. Currently, the foundations are built using the following technologies as part of our React TypeScript stack:
 
 - [Sprinkles](https://github.com/seek-oss/vanilla-extract/tree/master/packages/sprinkles), a CSS framework for vanilla-extract
 - [vanilla-extract](https://vanilla-extract.style), a CSS-in-JS library
 - [ViteJS](https://vitejs.dev), a frontend build tool
 
 For questions about our tech stack, go to [#polaris](https://shopify.slack.com/app_redirect?channel=polaris)
+
+### Contribute to our explorations
+
+We'd love to hear what you think. Start a conversation in [Github Discussions](https://github.com/Shopify/polaris/discussions)!
+
+---
+
+## Resources
+
+### Documentation
+
+- [Design tokens](packages/tokens/README.md)
+- [React components](packages/components/README.md)
+
+### NPM packages
+
+#### @shopify/layout-experimental
+
+An NPM package of experimental React components for layout, including abstractions for flexbox and grid, built with Vanilla Extract and Sprinkles.
+
+##### Install locally
+
+1. Add the dependency:
+
+NPM
+
+```shell
+npm install @shopify/layout-experimental
+```
+
+Yarn
+
+```shell
+yarn add @shopify/layout-experimental
+```
+
+2. Import the foundation styles at the base of your app:
+
+```jsx
+import '@shopify/layout-experimental/dist/style.css';
+```
+
+3. Read the [component API documentation](packages/components/README.md)
+
+##### Explore the sandbox
+
+We have created a [sandbox](https://codesandbox.io/s/layout-experimental-demo-wcxdj?file=/src/pages/index.js) utilizing the [experimental release](https://www.npmjs.com/package/@shopify/layout-experimental) of our foundational layout components: Box, Grid, Flex, and more. Check it out to see examples of how the components can be used and try them out yourself!

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -1,1 +1,180 @@
 # @polaris/components
+
+[Tokens](../tokens/README.md) | [Atoms](#atoms-shortcuts-helpers) | [Components](#component-api-reference)
+
+## Atoms (shortcuts, helpers)
+
+[Source code](https://github.com/Shopify/polaris/blob/master/packages/components/src/atoms/sprinkles.css.ts)
+
+Atoms are the smallest functional elements of the design foundation system. Using Sprinkles, we apply the [design tokens](packages/tokens/README.md) to common CSS properties alongside their natively accepted values and convert them into atoms. These atoms encapsulate common CSS rules into global classes to reduce redundant styles. Atoms are available in your React code in two ways: through props on each of our components and through the atoms function for use in .css.ts files to create custom classes.
+
+When an atomic prop is set on a component, the HTML renders with the corresponding atomic classes. For example, the `marginTop` prop accepts any of the spacing tokens. Setting the `marginTop` prop to `4` on a `Box` component sets a corresponding atomic class on the `div` it renders. That atomic class applies a custom CSS property that maps to a design token\*.
+
+| React code              | HTML rendered                                     | CSS applied                                 |
+| ----------------------- | ------------------------------------------------- | ------------------------------------------- |
+| `<Box marginTop=”4” />` | `<div class=”sprinkles_marginTop_4_hspcdy2ha” />` | `margin-top: var(--spacing-4\_\_1tfgtc0c);` |
+
+\*Note that atomic classes and custom CSS properties are partially obfuscated for performance. In future iterations, we plan to provide these atoms as their own resource to be consumed in non-React web projects and projects served on non-web platforms.
+
+### Responsive syntax
+
+Atomic props can be set responsively by passing an object having one, some, or all of the breakpoints as keys referencing the atomic values the prop accepts. This applies the atomic classes at the breakpoints you specify using media queries. For example:
+
+Set different values at each breakpoint
+
+```jsx
+paddingY={{
+  xs: '4',
+  sm: '8',
+  md: '12',
+  lg: '16',
+  xl: '20',
+}}
+```
+
+Set different values for mobile and for tablet and above
+
+```jsx
+paddingY={{
+  xs: '4',
+  sm: '8',
+}}
+```
+
+| Name   | Pixel width applied at             |
+| ------ | ---------------------------------- |
+| **xs** | _Mobile screen sizes (< 600px)_    |
+| **sm** | _Tablet screen sizes (>= 600px)_   |
+| **md** | _Laptop screen sizes (>= 960px)_   |
+| **lg** | _Desktop screen sizes (>= 1280px)_ |
+| **xl** | _4K screen sizes (>= 1920px)_      |
+
+### Space and size values
+
+The size atomic values below along with the [space atomic values](../tokens/README.md#spacing) are the accepted values for the [sizing](#sizing) and [spacing](#spacing) related atomic properties. For example, setting `width="1/2"` sets the class `sprinkles_width_1/2_xs__hspcdy40u` which applies the CSS rule `max-width: 50%;`.
+
+#### Size
+
+| Atomic value | CSS value  |
+| ------------ | ---------- |
+| auto         | auto       |
+| 1/2          | 50%        |
+| 1/3          | 33.333333% |
+| 2/3          | 66.666667% |
+| 1/4          | 25%        |
+| 2/4          | 50%        |
+| 3/4          | 75%        |
+| 1/5          | 20%        |
+| 2/5          | 40%        |
+| 3/5          | 60%        |
+| 4/5          | 80%        |
+| 1/6          | 16.666667% |
+| 2/6          | 33.333333% |
+| 3/6          | 50%        |
+| 4/6          | 66.666667% |
+| 5/6          | 83.333333% |
+| full         | 100%       |
+
+### Atomic property reference
+
+#### Interaction
+
+| Prop name         | Values accepted                                                                             |
+| ----------------- | ------------------------------------------------------------------------------------------- |
+| **cursor**        | “auto”, “default”, “pointer”, “grab”, “grabbing”                                            |
+| **outlineStyle**  | “auto”, “none”, “dotted”, “dashed”, “solid”, “double”, “groove”, “ridge”, “inset”, “outset” |
+| **pointerEvents** | “auto”, “none”                                                                              |
+| **userSelect**    | “none”, “auto”, “text”, “contain”, “all”                                                    |
+
+#### Borders
+
+| Prop name       | Values accepted                                                                             |
+| --------------- | ------------------------------------------------------------------------------------------- |
+| **borderStyle** | “auto”, “none”, “dotted”, “dashed”, “solid”, “double”, “groove”, “ridge”, “inset”, “outset” |
+
+#### Layout
+
+| Prop name                       | Values accepted                                                                                          |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **position**                    | “absolute”, “relative”, “static”, “sticky”, “initial”, “fixed”                                           |
+| **display**                     | “block”, “inline”, “inline-block”, “flex”, “inline-flex”, “grid”, “inline-grid”, “flow-root”, “contents” |
+| **top / left / right / bottom** | _Accepts any [size](#space-and-size-values) or [space](../tokens/README.md#spacing) atomic value._       |
+| **overflow**                    | “visible”, “hidden”, “clip”, “scroll”, “auto”, “initial”                                                 |
+| **placeContent**                | “center”                                                                                                 |
+
+#### Flexbox and Grid
+
+| Prop name          | Values accepted                                                                                |
+| ------------------ | ---------------------------------------------------------------------------------------------- |
+| **flex**           | “1”, “auto”, “initial”, “none”                                                                 |
+| **flexDirection**  | “row”, “column”, “row-reverse”, “column-reverse”                                               |
+| **flexGrow**       | “0”, “1”                                                                                       |
+| **flexShrink**     | “0”, “1”                                                                                       |
+| **flexWrap**       | “wrap, “nowrap”, “wrap-reverse”                                                                |
+| **gap**            | Uses spacing                                                                                   |
+| **justifyContent** | “flex-start”, “center”, “flex-end”, “stretch”, “space-around”, “space-evenly”, “space-between” |
+| **justifySelf**    | “flex-start”, “center”, “flex-end”, “stretch”                                                  |
+| **alignItems**     | “flex-start”, “center”, “flex-end”, “stretch”                                                  |
+| **alignSelf**      | “flex-start”, “center”, “flex-end”, “stretch”                                                  |
+
+#### Spacing
+
+##### Margin
+
+| Prop name        | Values accepted                                                                                  |
+| ---------------- | ------------------------------------------------------------------------------------------------ |
+| **margin**       | _Specifies margin to all sides. Accepts any [space atomic value](#space-and-size-values) value._ |
+| **marginTop**    | _Accepts any [space atomic value](../tokens/README.md#spacing)._                                 |
+| **marginLeft**   | _Accepts any [space atomic value](../tokens/README.md#spacing)._                                 |
+| **marginBottom** | _Accepts any [space atomic value](../tokens/README.md#spacing)._                                 |
+| **marginRight**  | _Accepts any [space atomic value](../tokens/README.md#spacing)._                                 |
+| **marginY**      | _Top and bottom margin. Accepts any [space atomic value](../tokens/README.md#spacing)._          |
+| **marginX**      | _Left and right margin. Accepts any [space atomic value](../tokens/README.md#spacing)._          |
+
+##### Padding
+
+| Prop name         | Values accepted                                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------- |
+| **padding**       | _Specifies padding for all sides. Accepts any [space atomic value](../tokens/README.md#spacing)._ |
+| **paddingTop**    | _Accepts any [space atomic value](../tokens/README.md#spacing)._                                  |
+| **paddingLeft**   | _Accepts any [space atomic value](../tokens/README.md#spacing)._                                  |
+| **paddingBottom** | _Accepts any [space atomic value](../tokens/README.md#spacing)._                                  |
+| **paddingRight**  | _Accepts any [space atomic value](../tokens/README.md#spacing)._                                  |
+| **paddingY**      | _Top and bottom padding. Accepts any [space atomic value](../tokens/README.md#spacing)._          |
+| **paddingX**      | _Left and right padding. Accepts any [space atomic value](../tokens/README.md#spacing)._          |
+
+#### Typography
+
+| Prop name              | Values accepted                                                     |
+| ---------------------- | ------------------------------------------------------------------- |
+| **textAlign**          | “left”, “right”, “center”                                           |
+| **textDecorationLine** | “none”, “underline”, “overline”, “line-through”, “blink”, “initial” |
+| **textDecoration**     | Shorthand for textDecorationLine                                    |
+| **whiteSpace**         | “normal”, “nowrap”, “pre”, “pre-wrap”, “pre-line”, “break-spaces”   |
+| **wordBreak**          | “normal”, “break-all”, “break-word”, “keep-all”, “initial”          |
+
+#### Sizing
+
+| Prop name | Values accepted                                                                                    |
+| --------- | -------------------------------------------------------------------------------------------------- |
+| height    | _Accepts any [size](#space-and-size-values) or [space](../tokens/README.md#spacing) atomic value._ |
+| maxHeight | _Accepts any [size](#space-and-size-values) or [space](../tokens/README.md#spacing) atomic value._ |
+| maxWidth  | _Accepts any [size](#space-and-size-values) or [space](../tokens/README.md#spacing) atomic value._ |
+| minHeight | _Accepts any [size](#space-and-size-values) or [space](../tokens/README.md#spacing) atomic value._ |
+| minWidth  | _Accepts any [size](#space-and-size-values) or [space](../tokens/README.md#spacing) atomic value._ |
+
+## Component API reference
+
+All components are polymorphic, which means they have an `as` prop that accepts a string HTML element name, like `"main"` or `"ul"` that specifies what element it will render. The `as` prop on most components defaults to `"div"` unless the component has a clear semantic purpose, in which case the default will be that semantic element. For example, `ButtonBase` and `Button` `as` props default to `"button"`, and `Link` defaults to `"a"`. Each component accepts all of the atomic props as well as any props native to the HTML element set on the `as` prop.
+
+As this project is in constant iteration, prop interfaces are subject to change, so in lieu of a props table for each component we've linked directly to its source code of each component so you can reference the props interface directly.
+
+| Name                                                | Visual example                                                                                                                                                                     | Description                                                                                                                                                                                        |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Box](src/components/Box/Box.tsx)                   | ![](https://lh6.googleusercontent.com/1mzSaJxIZbTiXxVCVmOtqQT46hxBDKbAOjucJ64rQnKY_USzzLPMIOlg-ywX0NP7RXoHKURxMGAjor81kFLckREgUbUh0lxlKXShKVHTsBMrxGfvMHRR2pEh5AF4QCrNKCceKIrx=s0) | Use to create custom components. Can be anything from a custom layout container to a custom button to a decorative box, you decide. Gives you access to all atoms through props.                   |
+| [Container](src/components/Container/Container.tsx) | ![](https://lh4.googleusercontent.com/D_KFJqoSp239E9KenIs07cj9UcN1IQcGhDzxJg38EY7JHXk-kh5xn3uvt6PsROobtAoDptk4n14OabuBQU4Ia5RviursV-SZwb2y-0tcoygfgHzCXVrlFkNhY3ndq1VBGpx0enx5=s0) | General content wrapper, likely a top level parent of several layout groups.                                                                                                                       |
+| [Grid](src/components/Grid/Grid.tsx)                | ![](https://lh5.googleusercontent.com/PXfqXiiylmHCD93G5k97NFqbUyn8QJZ0J-kYno4iGu_V6mZZS4St8q9sGPWVpfPJVezxcwJz08iib5LEtXdbR38WeVfuIjN7HPPe4PM3nBp6rbjFCb-CxiVgBsWx7X_cDh9iHRpE=s0) | Groups content together in defined areas, columns, and or rows. Use for custom layouts of content containers as well as complex custom micro layouts within a content container.                   |
+| [Flex](src/components/Flex/Flex.tsx)                | ![](https://lh3.googleusercontent.com/q6FBTc2e4ITXmrEl6YAH74IUdMZLIoxMcReUVdLwLUFJOBvitRaA8pgEbhIkr0eKG4WlzzkTSZEZtkQ6HVmJwF-db-Ug__ZYWx2ydjofTix7x9an20bE4ttcRW1VQE6jBU0-l2Y0=s0) | Groups content together in flexible columns and or rows, with or without wrapping. Use for simple custom layouts of content containers as well as simple micro layouts within a content container. |
+| [Center](src/components/Center/Center.tsx)          | ![](https://lh5.googleusercontent.com/9DDf7QOIc0k7CJX_9XlOQHroOs_qjK4EUjQWO7SQ4Pp1Ayi9ugGy5zSflsBh-nQs8eRHIwGY65pIPFlE-nVu0zOKggkMRItn7JWD0qKQS8kognH3EMw7qDGYQDH2WBzSVQmadxH1=s0) | Groups content together in a center aligned and justified row                                                                                                                                      |
+| [Inline](src/components/Inline/Inline.tsx)          | ![](https://lh5.googleusercontent.com/TehCOKYK4CQTEU5F6LwJZ6EF4XbooiJN3wQNfNmLhPzFk3PC0ZyQPVvHpo2x5j4ibpkhFm7vO2wlF78SqyCFeRK0djthOdRHPGZmV55n7nmjshTz6m4l2yhf2qXi17qPZT6kBEjo=s0) | Groups content together in a row                                                                                                                                                                   |
+| [Stack](src/components/Stack/Stack.tsx)             | ![](https://lh5.googleusercontent.com/6w4rJRXwBNan8MO3oEB9Ers0td2c_EHOkwLjQk5hYuPYeEog-pYW7l4Y5Fp2EqLDrYOP_1_gBoyWfK5AIXuYzux7cx2YxA3HufRBJtSC1RaTnUjy9biPAH1B7g1olq6m2I8mNNBe=s0) | Groups content together in a column                                                                                                                                                                |

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -1,6 +1,8 @@
 # @polaris/tokens
 
-Design tokens are design decisions that enable unified and cohesive product experiences.
+[Principles](#principles) | [Token reference](#token-reference) | [Token API](#token-api)
+
+Design tokens are design decisions in the form of data. Tokens are an agnostic way to store variables such as typography, color, and spacing so that they can be shared across platforms like iOS, Android, and web.d
 
 ## Principles
 
@@ -15,3 +17,81 @@ We believe that people should have a high quality experience that scales across 
 ### Cohesive
 
 We believe in creating a sense of cohesion through a shared set of foundational values. Audiences and their unique contexts impact the decisions we make. We recognize that certain audiences have different needs. We need to provide our users with a flexible foundation that enables them to solve audience specific problems while keeping a sense of cohesion across Shopify experiences.
+
+## Token reference
+
+### Breakpoints
+
+[Source code](/src/breakpoints.ts)
+
+| Atomic value | px value |
+| ------------ | -------- |
+| xs           | 0        |
+| sm           | 600px    |
+| md           | 960px    |
+| lg           | 1280px   |
+| xl           | 1920px   |
+
+### Spacing
+
+[Source code](/src/spacing.ts)
+
+base value = 4px | 1rem = 16px
+
+Formula
+token x base value = px value
+token / base value = rem value
+
+| Atomic value | px value | rem value |
+| ------------ | -------- | --------- |
+| \-1          | \-4      | \-0.25    |
+| \-1.5        | \-6      | \-0.375   |
+| \-2          | \-8      | \-0.5     |
+| \-2.5        | \-10     | \-0.625   |
+| \-3          | \-12     | \-0.75    |
+| \-3.5        | \-14     | \-0.875   |
+| \-4          | \-16     | \-1       |
+| \-5          | \-20     | \-1.25    |
+| \-6          | \-24     | \-1.5     |
+| \-7          | \-28     | \-1.75    |
+| \-8          | \-32     | \-2       |
+| \-9          | \-36     | \-2.25    |
+| \-10         | \-40     | \-2.5     |
+| 0            | 0        | 0         |
+| 0.5          | 2        | 0.125     |
+| 1            | 4        | 0.25      |
+| 1.5          | 6        | 0.375     |
+| 2            | 8        | 0.5       |
+| 2.5          | 10       | 0.625     |
+| 3            | 12       | 0.75      |
+| 3.5          | 14       | 0.875     |
+| 4 (base)     | 16px     | 1rem      |
+| 5            | 20       | 1.25      |
+| 6            | 24       | 1.5       |
+| 7            | 28       | 1.75      |
+| 8            | 32       | 2rem      |
+| 9            | 36       | 2.25      |
+| 10           | 40       | 2.5       |
+| 11           | 44       | 2.75      |
+| 12           | 48       | 3         |
+| 14           | 56       | 3.5       |
+| 16           | 64       | 4         |
+| 20           | 80       | 5         |
+| 24           | 96       | 6         |
+| 28           | 112      | 7         |
+| 32           | 128      | 8         |
+| 36           | 144      | 9         |
+| 40           | 160      | 10        |
+| 44           | 176      | 11        |
+| 48           | 192      | 12        |
+| 52           | 208      | 13        |
+| 56           | 224      | 14        |
+| 60           | 240      | 15        |
+| 64           | 256      | 16        |
+| 72           | 288      | 18        |
+| 80           | 320      | 20        |
+| 96           | 384      | 24        |
+
+## Token API
+
+Coming soon...


### PR DESCRIPTION
## TL;DR: 
This PR adds bare minimum documentation to the repo for the tokens and components packages and the project itself. 

## Approaches
There's three approaches we can take. I personally vote for the second approach, since the READMEs will auto show in the detail pages for the NPM packages when shipped and the content is co-located with the code it is documenting. Click the links below to experience each approach, then cast your vote 📬 

|  Approach | Pros  | Cons |
|---|---|---|
|[Approach 1 - Single README at the base of the project holds everything](https://github.com/Shopify/polaris/blob/e9b896f6870aaf67aa405f0e4f18597afca2d7b2/README.md)|No need to navigate to other pages to read the docs you need|Overwhelming wall of text; Have to do a lot of scrolling up and down or Cmd + F to re-find the content you're looking for after initially clicking a link in the table of contents at the top|
|[Approach 2 - Single README at the base of the project, READMEs at the base of each of the packages](https://github.com/Shopify/polaris/blob/d4a71041250360588ba4dc278ed3012fb1134cea/README.md)|Package docs close to their source code; Separation of concerns; Cross-links where relevant|Makes contribution to the docs less straight forward (not really relevant since the README approach is a temporary docs solution)|
|[Approach 3 - Single README at the base of the project, additional Markdown files in a `documentation` folder at the base of the project](https://github.com/Shopify/polaris/blob/9ba0d2e9c47dc091a59a9a7bda084f88a3fae95e/README.md)|Clear place to look for and contribute to docs|Docs not co-located with their source code|


## Caveats

### Component props
I've opted to not directly document the props of the components because they are experimental and subject to change. I'm going to add a link to the props definitions in the source code to the components table instead so there's no need to update in multiple places as things change.
